### PR TITLE
Replace raster PWA icons with SVG alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Ticket-mockup-test
+# Ticket Mockup
+
+Minimalny szkielet gry w Phaser 3 uruchamiany przez Vite + TypeScript.
+
+## Wymagania
+
+- Node.js 18+
+- npm
+
+## Instalacja i uruchomienie
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run preview
+```
+
+`npm run dev` startuje lokalny serwer Vite na porcie 5173. `npm run build` kompiluje kod TypeScript i buduje produkcyjny bundle, a `npm run preview` uruchamia lokalny serwer do podglądu zbudowanej aplikacji.
+
+## Rozdzielczość i skalowanie
+
+Gra działa na stałym wirtualnym stage'u o rozdzielczości 1920×1080. Konfiguracja `Phaser.Scale.FIT` zapewnia dopasowanie canvasa do okna przeglądarki bez przycinania — cała scena jest widoczna, a gra skaluje się proporcjonalnie tak, by zmieścić się w dostępnej przestrzeni.
+
+Domyślny preset rozmiaru UI jest definiowany w pliku [`src/ui/theme.ts`](src/ui/theme.ts) (wartość `M`). Można go zmienić, modyfikując pole `scale`, `minFont` oraz `minButtonHeight` dla wybranego presetu, albo ustawić inny preset jako domyślny podczas inicjalizacji gry.
+
+## API placeholder
+
+Plik [`src/services/api.ts`](src/services/api.ts) zawiera tymczasowe, mockowane funkcje komunikacji z backendem (`upsertUser`, `startSession`, `finishRound`, `finishSession`, `getHighScores`). Aktualnie funkcje logują przekazane parametry i zwracają `Promise.resolve({ ok: true })`. W kolejnych krokach zostaną podmienione na integrację z Google Sheets przez Google Apps Script.

--- a/icon-192.svg
+++ b/icon-192.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b1018" />
+      <stop offset="100%" stop-color="#1c2635" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="32" fill="url(#bg)" />
+  <g fill="none" stroke="#f3f7ff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="36" y="62" width="120" height="68" rx="14" />
+    <path d="M66 60V40m60 20V40" />
+    <path d="M66 130v22m60-22v22" />
+  </g>
+  <circle cx="96" cy="96" r="18" fill="#f6ad3c" />
+</svg>

--- a/icon-512.svg
+++ b/icon-512.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b1018" />
+      <stop offset="100%" stop-color="#1c2635" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="url(#bg)" />
+  <g fill="none" stroke="#f3f7ff" stroke-width="28" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="110" y="160" width="292" height="180" rx="36" />
+    <path d="M170 156V100m172 56V100" />
+    <path d="M170 352v70m172-70v70" />
+  </g>
+  <circle cx="256" cy="250" r="52" fill="#f6ad3c" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,34 @@
 <!DOCTYPE html>
-<html lang="pl">
-<head>
-  <meta charset="utf-8">
-  <title>Codex Test</title>
-</head>
-<body>
-  <h1>✅ Działa branch codex-ui!</h1>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="theme-color" content="#0b1018" />
+    <link rel="icon" type="image/svg+xml" href="/icon-192.svg" />
+    <link rel="apple-touch-icon" href="/icon-192.svg" />
+    <title>Ticket Mockup</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        background: #0b1018;
+        overflow: hidden;
+        font-family: 'Inter', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+      }
+      #app {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Ticket Mockup",
+  "short_name": "Tickets",
+  "display": "standalone",
+  "background_color": "#0b1018",
+  "theme_color": "#0b1018",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "type": "image/svg+xml",
+      "sizes": "192x192"
+    },
+    {
+      "src": "/icon-512.svg",
+      "type": "image/svg+xml",
+      "sizes": "512x512"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,993 @@
+{
+  "name": "ticket-mockup",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ticket-mockup",
+      "version": "0.0.1",
+      "dependencies": {
+        "phaser": "^3.70.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.17",
+        "typescript": "^5.3.3",
+        "vite": "^5.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/phaser": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
+      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ticket-mockup",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "echo \"No lint configured yet\""
+  },
+  "dependencies": {
+    "phaser": "^3.70.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,67 @@
+import Phaser from 'phaser';
+import { Boot } from './scenes/Boot';
+import { Menu } from './scenes/Menu';
+import { Game } from './scenes/Game';
+import { Results } from './scenes/Results';
+import { theme } from './ui/theme';
+
+document.addEventListener(
+  'touchmove',
+  (event) => {
+    const touchEvent = event as TouchEvent;
+    if (touchEvent.touches.length > 1) {
+      event.preventDefault();
+    }
+  },
+  { passive: false }
+);
+
+document.addEventListener(
+  'touchstart',
+  (event) => {
+    if ((event as TouchEvent).touches.length > 1) {
+      event.preventDefault();
+    }
+  },
+  { passive: false }
+);
+
+document.addEventListener('gesturestart', (event) => event.preventDefault());
+document.addEventListener('gesturechange', (event) => event.preventDefault());
+document.addEventListener('gestureend', (event) => event.preventDefault());
+
+document.body.style.backgroundColor = theme.colors.backgroundHex;
+document.body.style.margin = '0';
+document.body.style.overflow = 'hidden';
+document.body.style.touchAction = 'manipulation';
+document.body.style.height = '100%';
+document.documentElement.style.height = '100%';
+
+type SceneConstructor = new (...args: any[]) => Phaser.Scene;
+
+const scenes: SceneConstructor[] = [Boot, Menu, Game, Results];
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  parent: 'app',
+  backgroundColor: theme.colors.background,
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 1920,
+    height: 1080
+  },
+  scene: scenes,
+  dom: {
+    createContainer: true
+  },
+  input: {
+    activePointers: 3
+  }
+};
+
+export const game = new Phaser.Game(config);
+
+window.addEventListener('resize', () => {
+  game.scale.refresh();
+});

--- a/src/scenes/Boot.ts
+++ b/src/scenes/Boot.ts
@@ -1,0 +1,34 @@
+import Phaser from 'phaser';
+import { theme } from '../ui/theme';
+
+export class Boot extends Phaser.Scene {
+  constructor() {
+    super('Boot');
+  }
+
+  preload(): void {
+    this.load.setPath('');
+    const size = 256;
+    const graphics = this.add.graphics({ x: 0, y: 0 });
+    graphics.setVisible(false);
+    graphics.fillStyle(theme.colors.accent, 1);
+    graphics.fillRoundedRect(0, 0, size, size, 32);
+    graphics.lineStyle(10, theme.colors.surface, 1);
+    graphics.strokeRoundedRect(0, 0, size, size, 32);
+    graphics.generateTexture('button-surface', size, size);
+    graphics.clear();
+
+    graphics.fillStyle(theme.colors.surface, 1);
+    graphics.fillRoundedRect(0, 0, size, size, 32);
+    graphics.generateTexture('button-background', size, size);
+    graphics.destroy();
+  }
+
+  create(): void {
+    this.scale.on('resize', (gameSize: Phaser.Structs.Size) => {
+      this.cameras.main.setViewport(0, 0, gameSize.width, gameSize.height);
+    });
+
+    this.scene.start('Menu');
+  }
+}

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -1,0 +1,221 @@
+import Phaser from 'phaser';
+import { theme } from '../ui/theme';
+import type { GameMode, GameResults, GameSettings } from '../types';
+
+interface GameSceneData {
+  settings?: GameSettings;
+}
+
+export class Game extends Phaser.Scene {
+  private settings!: GameSettings;
+  private countdown = 20;
+  private timerText!: Phaser.GameObjects.Text;
+  private score = 0;
+  private scoreText!: Phaser.GameObjects.Text;
+  private overlayText!: Phaser.GameObjects.Text;
+  private passengerCountdownEvent?: Phaser.Time.TimerEvent;
+
+  constructor() {
+    super('Game');
+  }
+
+  init(data: GameSceneData): void {
+    const lastSettings = this.registry.get('lastGameSettings') as GameSettings | undefined;
+    this.settings = data.settings ?? lastSettings ?? {
+      name: '',
+      mode: 'TB1',
+      uiSize: 'M'
+    };
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor(theme.colors.backgroundHex);
+    this.countdown = 20;
+    this.score = 0;
+
+    const preset = theme.presets[this.settings.uiSize];
+    const headingSize = theme.fontSizes.heading * preset.scale;
+    const bodySize = Math.max(theme.fontSizes.body, preset.minFont) * preset.scale * 0.75;
+    const labelSize = theme.fontSizes.label * preset.scale;
+
+    const hudBackground = this.add.rectangle(960, 80, 1400, 120, theme.colors.surface, 0.65);
+    hudBackground.setStrokeStyle(4, theme.colors.accent);
+
+    this.scoreText = this.add
+      .text(360, 72, `Score: ${this.score}`, {
+        fontSize: `${labelSize}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.textPrimary
+      })
+      .setOrigin(0.5);
+
+    this.timerText = this.add
+      .text(960, 72, `Timer: ${this.countdown}`, {
+        fontSize: `${labelSize}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.textPrimary
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(1560, 72, `Mode: ${this.settings.mode}`, {
+        fontSize: `${labelSize}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.textPrimary
+      })
+      .setOrigin(0.5);
+
+    const layoutDescription = this.describeLayout(this.settings.mode);
+    this.add
+      .text(960, 200, layoutDescription, {
+        fontSize: `${bodySize * 1.1}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.textMuted,
+        align: 'center'
+      })
+      .setOrigin(0.5);
+
+    const buttonWidth = 480 * preset.scale;
+    const buttonHeight = Math.max(220, preset.minButtonHeight * 3);
+
+    const ticketsButton = this.createLargeButton(650, 650, buttonWidth, buttonHeight, 'Tickets', headingSize);
+    const coinsButton = this.createLargeButton(1270, 650, buttonWidth, buttonHeight, 'Coins', headingSize);
+
+    ticketsButton.on('pointerdown', () => this.flashButton(ticketsButton));
+    coinsButton.on('pointerdown', () => this.flashButton(coinsButton));
+
+    this.overlayText = this.add.text(960, 450, '', {
+      fontSize: `${headingSize}px`,
+      fontFamily: 'Inter, Roboto, sans-serif',
+      color: theme.colors.textPrimary,
+      align: 'center'
+    });
+    this.overlayText.setOrigin(0.5);
+    this.overlayText.setAlpha(0);
+
+    this.time.addEvent({
+      delay: 1000,
+      loop: true,
+      callback: () => {
+        this.countdown -= 1;
+        this.timerText.setText(`Timer: ${Math.max(0, this.countdown)}`);
+        if (this.countdown <= 0) {
+          this.endRound();
+        }
+      }
+    });
+
+    this.time.addEvent({
+      delay: 500,
+      loop: true,
+      callback: () => {
+        this.score += Phaser.Math.Between(5, 15);
+        this.scoreText.setText(`Score: ${this.score}`);
+      }
+    });
+
+    this.startPassengerCountdown();
+    this.scale.refresh();
+    this.input.addPointer(1);
+  }
+
+  private describeLayout(mode: GameMode): string {
+    switch (mode) {
+      case 'TB1':
+        return 'Layout: Top & Bottom focus with queue at the sides.';
+      case 'TB2':
+        return 'Layout: Top/Bottom with split ticket validation.';
+      case 'HR1':
+        return 'Layout: Horizontal counters with dual panels.';
+      case 'HR2':
+        return 'Layout: Horizontal counters with mirrored controls.';
+      default:
+        return 'Layout: Placeholder configuration.';
+    }
+  }
+
+  private createLargeButton(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    label: string,
+    fontSize: number
+  ): Phaser.GameObjects.Container {
+    const container = this.add.container(x, y);
+    const background = this.add.rectangle(0, 0, width, height, theme.colors.surface);
+    background.setStrokeStyle(6, theme.colors.accent);
+    background.setInteractive({ useHandCursor: true });
+
+    const text = this.add.text(0, 0, label, {
+      fontSize: `${fontSize}px`,
+      fontFamily: 'Inter, Roboto, sans-serif',
+      color: theme.colors.textPrimary,
+      align: 'center'
+    });
+    text.setOrigin(0.5);
+
+    container.add([background, text]);
+    container.setSize(width, height);
+    container.setInteractive(new Phaser.Geom.Rectangle(-width / 2, -height / 2, width, height), Phaser.Geom.Rectangle.Contains);
+    container.on('pointerover', () => background.setFillStyle(theme.colors.surface, 0.9));
+    container.on('pointerout', () => background.setFillStyle(theme.colors.surface, 1));
+    container.on('pointerdown', () => background.setFillStyle(theme.colors.surface, 1));
+
+    return container;
+  }
+
+  private flashButton(button: Phaser.GameObjects.Container): void {
+    this.tweens.add({
+      targets: button,
+      scale: 0.98,
+      duration: 80,
+      yoyo: true,
+      repeat: 1,
+      ease: 'Sine.easeInOut'
+    });
+  }
+
+  private startPassengerCountdown(): void {
+    if (this.passengerCountdownEvent) {
+      this.passengerCountdownEvent.remove(false);
+    }
+
+    let countdown = 5;
+    this.overlayText.setText(`Next passenger in ${countdown}`);
+    this.overlayText.setAlpha(0.92);
+
+    this.passengerCountdownEvent = this.time.addEvent({
+      delay: 1000,
+      repeat: 4,
+      callback: () => {
+        countdown -= 1;
+        if (countdown > 0) {
+          this.overlayText.setText(`Next passenger in ${countdown}`);
+        } else {
+          this.overlayText.setText('Passenger ready!');
+          this.time.delayedCall(600, () => {
+            this.overlayText.setAlpha(0);
+          });
+        }
+      }
+    });
+
+    this.time.addEvent({
+      delay: 6000,
+      callback: () => {
+        if (this.scene.isActive() && this.countdown > 0) {
+          this.startPassengerCountdown();
+        }
+      }
+    });
+  }
+
+  private endRound(): void {
+    const results: GameResults = {
+      score: this.score,
+      settings: this.settings
+    };
+    this.scene.start('Results', results);
+  }
+}

--- a/src/scenes/Menu.ts
+++ b/src/scenes/Menu.ts
@@ -1,0 +1,262 @@
+import Phaser from 'phaser';
+import { theme, UISizePreset } from '../ui/theme';
+import type { GameMode, GameSettings } from '../types';
+
+const MODES: GameMode[] = ['TB1', 'TB2', 'HR1', 'HR2'];
+
+const LOCAL_STORAGE_KEYS = {
+  name: 'ticket-mockup:name',
+  mode: 'ticket-mockup:mode',
+  uiSize: 'ticket-mockup:ui-size'
+} as const;
+
+export class Menu extends Phaser.Scene {
+  private domForm?: Phaser.GameObjects.DOMElement;
+  private uiSize: UISizePreset = 'M';
+
+  constructor() {
+    super('Menu');
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor(theme.colors.backgroundHex);
+    const savedName = localStorage.getItem(LOCAL_STORAGE_KEYS.name) ?? '';
+    const savedMode = (localStorage.getItem(LOCAL_STORAGE_KEYS.mode) as GameMode | null) ?? 'TB1';
+    const savedSize = (localStorage.getItem(LOCAL_STORAGE_KEYS.uiSize) as UISizePreset | null) ?? 'M';
+    this.uiSize = savedSize;
+
+    const html = this.renderForm(savedName, savedMode, savedSize);
+    this.domForm = this.add.dom(960, 540).createFromHTML(html);
+    this.domForm.setOrigin(0.5);
+
+    const node = this.domForm.node as HTMLFormElement;
+    this.applySelectionStyles(node);
+    this.refreshStyles();
+
+    node.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(node);
+      const name = String(formData.get('name') ?? '').trim();
+      const mode = (formData.get('mode') as GameMode | null) ?? 'TB1';
+      const uiSize = (formData.get('uiSize') as UISizePreset | null) ?? 'M';
+
+      const settings: GameSettings = {
+        name,
+        mode,
+        uiSize
+      };
+
+      localStorage.setItem(LOCAL_STORAGE_KEYS.name, name);
+      localStorage.setItem(LOCAL_STORAGE_KEYS.mode, mode);
+      localStorage.setItem(LOCAL_STORAGE_KEYS.uiSize, uiSize);
+
+      this.registry.set('lastGameSettings', settings);
+      this.scene.start('Game', { settings });
+    });
+
+    node.addEventListener('change', (event) => {
+      const target = event.target as HTMLInputElement | HTMLSelectElement;
+      if (!target?.name) return;
+      if (target.name === 'uiSize') {
+        const value = target.value as UISizePreset;
+        this.uiSize = value;
+        localStorage.setItem(LOCAL_STORAGE_KEYS.uiSize, value);
+        this.refreshStyles();
+      }
+      if (target.name === 'mode') {
+        localStorage.setItem(LOCAL_STORAGE_KEYS.mode, target.value);
+      }
+      if (target.name === 'name') {
+        localStorage.setItem(LOCAL_STORAGE_KEYS.name, target.value);
+      }
+      this.applySelectionStyles(node);
+    });
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.domForm?.destroy();
+    });
+  }
+
+  private renderForm(name: string, mode: GameMode, uiSize: UISizePreset): string {
+    const sizeOptions = ['S', 'M', 'L'] as const;
+    const modeOptions = MODES.map(
+      (value) => `
+        <label class="option">
+          <input type="radio" name="mode" value="${value}" ${value === mode ? 'checked' : ''} />
+          <span>${value}</span>
+        </label>
+      `
+    ).join('');
+
+    const sizeOptionElements = sizeOptions
+      .map(
+        (value) => `
+          <label class="option compact">
+            <input type="radio" name="uiSize" value="${value}" ${value === uiSize ? 'checked' : ''} />
+            <span>${value}</span>
+          </label>
+        `
+      )
+      .join('');
+
+    const endlessDisabled = 'disabled';
+
+    return `
+      <form class="menu" autocomplete="off">
+        <style>
+          :root {
+            color-scheme: dark;
+          }
+          .menu {
+            width: min(560px, 90vw);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            padding: 32px;
+            border-radius: 24px;
+            background: rgba(17, 24, 39, 0.92);
+            box-shadow: 0 24px 64px rgba(0, 0, 0, 0.35);
+            color: ${theme.colors.textPrimary};
+            font-family: 'Inter', 'Roboto', sans-serif;
+            backdrop-filter: blur(8px);
+          }
+          h1 {
+            margin: 0 0 4px 0;
+            font-size: 2.25rem;
+            letter-spacing: 0.02em;
+            text-align: center;
+          }
+          p.subtitle {
+            margin: 0 0 16px 0;
+            text-align: center;
+            color: ${theme.colors.textMuted};
+          }
+          label.field {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-weight: 600;
+            font-size: 1.15rem;
+          }
+          input[type="text"] {
+            padding: 14px 16px;
+            border-radius: 12px;
+            border: none;
+            background: ${theme.colors.surfaceAltHex};
+            color: ${theme.colors.textPrimary};
+            font-size: 1.1rem;
+          }
+          .options {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+          }
+          .option {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 12px 16px;
+            background: ${theme.colors.surfaceAltHex};
+            border-radius: 12px;
+            cursor: pointer;
+            border: 2px solid transparent;
+            min-height: 48px;
+            font-size: 1.1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+          }
+          .option.compact {
+            justify-content: center;
+            min-width: 72px;
+          }
+          .option input {
+            width: 20px;
+            height: 20px;
+          }
+          .option.active {
+            border-color: ${theme.colors.accentHex};
+            box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.3);
+          }
+          .option input:disabled + span {
+            opacity: 0.45;
+          }
+          button.start {
+            margin-top: 10px;
+            padding: 18px 24px;
+            font-size: 1.2rem;
+            font-weight: 700;
+            border-radius: 14px;
+            border: none;
+            color: #0b1018;
+            background: ${theme.colors.accentHex};
+            cursor: pointer;
+            min-height: 56px;
+          }
+          button.start:active {
+            transform: translateY(1px);
+          }
+          .checkbox-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: ${theme.colors.textMuted};
+            font-size: 1.05rem;
+          }
+          .preset-label {
+            font-size: 1.05rem;
+            font-weight: 600;
+          }
+        </style>
+        <h1>Boarding Ready?</h1>
+        <p class="subtitle">Set your preferences and start the next shift.</p>
+        <label class="field">
+          Name
+          <input type="text" name="name" placeholder="Your name" value="${name}" required minlength="1" />
+        </label>
+        <div>
+          <div class="preset-label">Mode</div>
+          <div class="options">
+            ${modeOptions}
+          </div>
+        </div>
+        <label class="checkbox-row">
+          <input type="checkbox" name="endless" ${endlessDisabled} />
+          Endless (coming soon)
+        </label>
+        <div>
+          <div class="preset-label">UI size</div>
+          <div class="options">
+            ${sizeOptionElements}
+          </div>
+        </div>
+        <button class="start" type="submit">Start</button>
+      </form>
+    `;
+  }
+
+  private refreshStyles(): void {
+    if (!this.domForm) return;
+    const node = this.domForm.node as HTMLFormElement;
+    const baseFont = Math.max(theme.fontSizes.body, theme.presets[this.uiSize].minFont);
+    node.querySelectorAll('.menu').forEach((element) => {
+      const el = element as HTMLElement;
+      el.style.fontSize = `${baseFont}px`;
+    });
+    node.querySelectorAll('.option, .start').forEach((element) => {
+      const el = element as HTMLElement;
+      el.style.minHeight = `${theme.presets[this.uiSize].minButtonHeight}px`;
+      el.style.fontSize = `${baseFont}px`;
+    });
+    node.querySelectorAll('input[type="text"]').forEach((element) => {
+      const el = element as HTMLElement;
+      el.style.fontSize = `${baseFont}px`;
+    });
+  }
+
+  private applySelectionStyles(container: HTMLElement): void {
+    container.querySelectorAll('.option').forEach((element) => {
+      const el = element as HTMLElement;
+      const input = el.querySelector('input');
+      el.classList.toggle('active', !!input && (input as HTMLInputElement).checked);
+    });
+  }
+}

--- a/src/scenes/Results.ts
+++ b/src/scenes/Results.ts
@@ -1,0 +1,99 @@
+import Phaser from 'phaser';
+import { theme } from '../ui/theme';
+import type { GameResults } from '../types';
+
+export class Results extends Phaser.Scene {
+  private results!: GameResults;
+
+  constructor() {
+    super('Results');
+  }
+
+  init(data: GameResults): void {
+    this.results = data;
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor(theme.colors.backgroundHex);
+
+    const preset = theme.presets[this.results.settings.uiSize];
+    const headingSize = theme.fontSizes.heading * preset.scale * 1.4;
+    const buttonHeight = Math.max(preset.minButtonHeight, 80);
+    const buttonWidth = 380 * preset.scale;
+
+    this.add
+      .text(960, 220, 'Shift complete!', {
+        fontSize: `${headingSize}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.textPrimary,
+        align: 'center'
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(960, 380, `Score: ${this.results.score}`, {
+        fontSize: `${headingSize * 0.8}px`,
+        fontFamily: 'Inter, Roboto, sans-serif',
+        color: theme.colors.accentHex,
+        align: 'center'
+      })
+      .setOrigin(0.5);
+
+    const buttonContainer = this.add.container(960, 620);
+    buttonContainer.add([
+      this.createButton(-buttonWidth / 2 - 20, 0, buttonWidth, buttonHeight, 'Play again'),
+      this.createButton(buttonWidth / 2 + 20, 0, buttonWidth, buttonHeight, 'Back to Menu')
+    ]);
+
+    const buttons = buttonContainer.list as Phaser.GameObjects.Container[];
+    const playAgain = buttons[0];
+    const backToMenu = buttons[1];
+
+    playAgain.on('pointerdown', () => {
+      this.scene.start('Game', { settings: this.results.settings });
+    });
+
+    backToMenu.on('pointerdown', () => {
+      this.scene.start('Menu');
+    });
+  }
+
+  private createButton(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    label: string
+  ): Phaser.GameObjects.Container {
+    const container = this.add.container(x, y);
+    const background = this.add.rectangle(0, 0, width, height, theme.colors.surface, 0.95);
+    background.setStrokeStyle(4, theme.colors.accent);
+    background.setInteractive({ useHandCursor: true });
+
+    const text = this.add.text(0, 0, label, {
+      fontSize: `${Math.max(28, theme.fontSizes.label)}px`,
+      fontFamily: 'Inter, Roboto, sans-serif',
+      color: theme.colors.textPrimary,
+      align: 'center'
+    });
+    text.setOrigin(0.5);
+
+    container.add([background, text]);
+    container.setSize(width, height);
+    container.setInteractive(new Phaser.Geom.Rectangle(-width / 2, -height / 2, width, height), Phaser.Geom.Rectangle.Contains);
+    container.on('pointerover', () => background.setFillStyle(theme.colors.surface, 1));
+    container.on('pointerout', () => background.setFillStyle(theme.colors.surface, 0.95));
+    container.on('pointerdown', () => {
+      background.setFillStyle(theme.colors.surface, 1);
+      this.tweens.add({
+        targets: container,
+        scale: 0.97,
+        duration: 90,
+        yoyo: true,
+        ease: 'Sine.easeInOut'
+      });
+    });
+
+    return container;
+  }
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,32 @@
+/* Placeholder API layer that will be replaced with Google Apps Script endpoints. */
+
+type SessionPayload = Record<string, unknown>;
+
+type HighScoreResponse = Promise<{ ok: true }>;
+
+type DefaultResponse = Promise<{ ok: true }>;
+
+export function upsertUser(name: string): DefaultResponse {
+  console.info('[api] upsertUser', { name });
+  return Promise.resolve({ ok: true });
+}
+
+export function startSession(payload: SessionPayload): DefaultResponse {
+  console.info('[api] startSession', payload);
+  return Promise.resolve({ ok: true });
+}
+
+export function finishRound(payload: SessionPayload): DefaultResponse {
+  console.info('[api] finishRound', payload);
+  return Promise.resolve({ ok: true });
+}
+
+export function finishSession(payload: SessionPayload): DefaultResponse {
+  console.info('[api] finishSession', payload);
+  return Promise.resolve({ ok: true });
+}
+
+export function getHighScores(mode: string): HighScoreResponse {
+  console.info('[api] getHighScores', { mode });
+  return Promise.resolve({ ok: true });
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,20 @@
+import type { UISizePreset } from './ui/theme';
+
+export type GameMode = 'TB1' | 'TB2' | 'HR1' | 'HR2';
+
+export interface GameSettings {
+  name: string;
+  mode: GameMode;
+  uiSize: UISizePreset;
+}
+
+export interface GameResults {
+  score: number;
+  settings: GameSettings;
+}
+
+declare global {
+  // Phaser's legacy XML parser types reference ActiveXObject on older browsers.
+  type ActiveXObject = unknown;
+}
+

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,37 @@
+export type UISizePreset = 'S' | 'M' | 'L';
+
+export const theme = {
+  colors: {
+    background: 0x0b1018,
+    backgroundHex: '#0b1018',
+    surface: 0x111827,
+    surfaceHex: '#111827',
+    surfaceAltHex: '#1f2937',
+    accent: 0x38bdf8,
+    accentHex: '#38bdf8',
+    textPrimary: '#ffffff',
+    textMuted: '#94a3b8'
+  },
+  fontSizes: {
+    heading: 48,
+    label: 28,
+    body: 22
+  },
+  presets: {
+    S: {
+      scale: 1,
+      minFont: 22,
+      minButtonHeight: 48
+    },
+    M: {
+      scale: 1.15,
+      minFont: 26,
+      minButtonHeight: 56
+    },
+    L: {
+      scale: 1.3,
+      minFont: 30,
+      minButtonHeight: 64
+    }
+  } as Record<UISizePreset, { scale: number; minFont: number; minButtonHeight: number }>
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "lib": ["DOM", "ES2020"],
+    "types": ["phaser", "node"],
+    "baseUrl": "./",
+    "paths": {
+      "@scenes/*": ["src/scenes/*"],
+      "@ui/*": ["src/ui/*"],
+      "@services/*": ["src/services/*"],
+      "@types": ["src/types.d.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- replace the PNG app icons with vector SVG assets to avoid binary files
- update the PWA manifest and HTML metadata to reference the new SVG icons
- remove the unused PNG module declaration from the shared types file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d674343fb483298fdab852077086bb